### PR TITLE
Bump to JMeter 5.0 & add granularity params for short term test

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,6 +2,9 @@ jmeter/apache-jmeter-3.0_1.tgz:
   size: 45178166
   object_id: e28d6f50-1c64-41ca-6352-2dcffdbb9894
   sha: 0063516826add27a49eb391e61a6a60dc8065813
+jmeter/apache-jmeter-5.0_rmi.tgz:
+  size: 53908732
+  sha: 9df3ec29e6c7f64b396fbffcf1ae4c70128d6f01
 openjdk/openjdk-1.8.0_101-x86_64-trusty.tar.gz:
   size: 77696717
   object_id: b9565d3c-8899-41ea-440d-2ff2d84269a3

--- a/jobs/jmeter_storm/spec
+++ b/jobs/jmeter_storm/spec
@@ -109,6 +109,13 @@ properties:
   generate_dashboard:
     description: Apply "--reportatendofloadtests" when running jmeter
     default: true
+  
+  jmeter.reportgenerator.overall_granularity:
+    description: Granularity of over time graphs.
+    help: |
+      Taken From JMeter Documention
+        "Granularity of over time graphs. Data is aggregated to have 1 minute ticks.
+        Granularity must be higher than 1 second (1000) otherwise throughput graphs will be incorrect"
 
   # ==================================================================================================
   # ==================================================================================================

--- a/jobs/jmeter_storm/spec
+++ b/jobs/jmeter_storm/spec
@@ -6,6 +6,7 @@ templates:
   settings.json.erb: config/settings.json
   validation.txt.erb: config/validation.txt
   raw_test_plan.jmx.erb: config/raw_test_plan.jmx
+  user.properties.erb: config/user.properties
 
 packages:
 - jmeter
@@ -110,13 +111,6 @@ properties:
     description: Apply "--reportatendofloadtests" when running jmeter
     default: true
   
-  jmeter.reportgenerator.overall_granularity:
-    description: Granularity of over time graphs.
-    help: |
-      Taken From JMeter Documention
-        "Granularity of over time graphs. Data is aggregated to have 1 minute ticks.
-        Granularity must be higher than 1 second (1000) otherwise throughput graphs will be incorrect"
-
   # ==================================================================================================
   # ==================================================================================================
   # JVM Options
@@ -191,3 +185,12 @@ properties:
       # in tenuring longer than the life of per-sample objects -- which is hopefully
       # shorter than the period between two scavenges):
       # TENURING="-XX:MaxTenuringThreshold=2"
+
+  # ==================================================================================================
+  # ==================================================================================================
+  # User Properties
+  user_properties:
+    description: Additional JMeter properties
+    default: []
+    help: |
+      Reporting configuration (https://jmeter.apache.org/usermanual/generating-dashboard.html#configuration)

--- a/jobs/jmeter_storm/templates/run.erb
+++ b/jobs/jmeter_storm/templates/run.erb
@@ -50,6 +50,15 @@ cp $JMX_PLAN_FILE $LOG_DIR/generated_test_plan.jmx
 
 pushd /var/vcap/packages/jmeter/bin
 
+<%
+  user_properties = []
+  if_p('jmeter.reportgenerator.overall_granularity') do
+    user_properties.push("jmeter.reportgenerator.overall_granularity=" << p("jmeter.reportgenerator.overall_granularity").to_s)
+  end
+%>
+
+echo '<%=user_properties.join("\n")%>' > user.properties
+
 java $JVM_ARGS -jar "ApacheJMeter.jar" \
     --nongui \
     --testfile $JMX_PLAN_FILE \

--- a/jobs/jmeter_storm/templates/run.erb
+++ b/jobs/jmeter_storm/templates/run.erb
@@ -23,6 +23,7 @@ JMETER_LOG_FILE=$LOG_DIR/jmeter.log
 STDOUT_LOG_FILE=$LOG_DIR/${JOB_NAME}.stdout.log
 STDERR_LOG_FILE=$LOG_DIR/${JOB_NAME}.stderr.log
 GENERATE_DASHBOARD=<% if p('generate_dashboard') %>"--reportatendofloadtests --reportoutputfolder $LOG_DIR/dashboard"<%end%>
+PROPERTY_FILE=/var/vcap/jobs/${JOB_NAME}/config/user.properties
 RMI_HOST_DEF=-Djava.rmi.server.hostname=<%=spec.networks.to_h.values.first.ip%>
 
 # JAVA options
@@ -51,15 +52,6 @@ cp $JMX_PLAN_FILE $LOG_DIR/generated_test_plan.jmx
 
 pushd /var/vcap/packages/jmeter/bin
 
-<%
-  user_properties = []
-  if_p('jmeter.reportgenerator.overall_granularity') do
-    user_properties.push("jmeter.reportgenerator.overall_granularity=" << p("jmeter.reportgenerator.overall_granularity").to_s)
-  end
-%>
-
-echo '<%=user_properties.join("\n")%>' > user.properties
-
 java $JVM_ARGS -jar "ApacheJMeter.jar" \
     ${RMI_HOST_DEF} \
     --nongui \
@@ -67,4 +59,5 @@ java $JVM_ARGS -jar "ApacheJMeter.jar" \
     --remotestart $SERVERS_IP_ADDRESSES \
     --jmeterlogfile $JMETER_LOG_FILE \
     --logfile $PLAN_EXECUTION_RESULT_FILE \
+    --addprop $PROPERTY_FILE \
     $GENERATE_DASHBOARD >> $STDOUT_LOG_FILE 2>> $STDERR_LOG_FILE

--- a/jobs/jmeter_storm/templates/run.erb
+++ b/jobs/jmeter_storm/templates/run.erb
@@ -23,6 +23,7 @@ JMETER_LOG_FILE=$LOG_DIR/jmeter.log
 STDOUT_LOG_FILE=$LOG_DIR/${JOB_NAME}.stdout.log
 STDERR_LOG_FILE=$LOG_DIR/${JOB_NAME}.stderr.log
 GENERATE_DASHBOARD=<% if p('generate_dashboard') %>"--reportatendofloadtests --reportoutputfolder $LOG_DIR/dashboard"<%end%>
+RMI_HOST_DEF=-Djava.rmi.server.hostname=<%=spec.networks.to_h.values.first.ip%>
 
 # JAVA options
 SERVER="-server" # optimize JAVA performance
@@ -60,6 +61,7 @@ pushd /var/vcap/packages/jmeter/bin
 echo '<%=user_properties.join("\n")%>' > user.properties
 
 java $JVM_ARGS -jar "ApacheJMeter.jar" \
+    ${RMI_HOST_DEF} \
     --nongui \
     --testfile $JMX_PLAN_FILE \
     --remotestart $SERVERS_IP_ADDRESSES \

--- a/jobs/jmeter_storm/templates/user.properties.erb
+++ b/jobs/jmeter_storm/templates/user.properties.erb
@@ -1,0 +1,12 @@
+<%=
+
+params = []
+if_p('user_properties') do |properties|
+  properties.each do |property|
+    params << property.fetch("name")+"="+property.fetch("value").to_s
+  end
+end
+
+params.join("\n")
+
+%>

--- a/packages/jmeter/spec
+++ b/packages/jmeter/spec
@@ -5,4 +5,4 @@ dependencies:
 - openjdk
 
 files:
-- jmeter/apache-jmeter-3.0_1.tgz
+- jmeter/apache-jmeter-5.0_rmi.tgz


### PR DESCRIPTION
## Bump to JMeter 5.0
Update JMeter 3.0 -> 5.0.

I tested it works on ubuntu-trusty, ubuntu-xenial. (on BOSH-Lite & AWS)

### RMI Inserted package
JMeter 5.0 cluster requires **RMI-Keystore**, therefore I was create it by `jmeter/bin/create-rmi-keystore.sh` and inserted to package directory.
**Please download rmi inserted package from here and upload to your blobstore.**

https://s3-ap-northeast-1.amazonaws.com/d703n-bosh-tmp-blobs/apache-jmeter-5.0_rmi.tgz

### test.sh logs
[20190126_0245_jmeter-test.log](https://github.com/jamlo/jmeter-bosh-release/files/2798605/20190126_0245_jmeter-test.log)

**Note1**: I changed log waiting time 1s -> 10s, because of poor spec, request sequence does not finish in 1s.

**Note2**: `storm_mode`/`gaussian-random-timer-request.yml` does not be passed... Please re-test on your environment. Failed reason is as below, caused by poor spec?

> BROKEN: I found '6' occurances of '"GET /greeting/get/smurf HTTP/1.1" 200', expected '8'

## Additional User Properties
Enabled to setting some properties on `user.properties`.

**Example of use**

Granularity parameter(default:60000ms) for short term test. (https://jmeter.apache.org/usermanual/generating-dashboard.html#configuration)

```
- name: storm
  lifecycle: errand
  jobs:
  - name: jmeter_storm
    release: jmeter-tornado
    properties:
      user_properties:
      - name: jmeter.reportgenerator.overall_granularity
        value: 10000
      - name: <some other user property>
        value: ...
```